### PR TITLE
Build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/tmp/
 /.settings
 /.buildpath
 /.project

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/release/
 /tmp/
 /.settings
 /.buildpath

--- a/Build
+++ b/Build
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+BASE=$(cd $(dirname "$0") && pwd -P)
+
+run_tests() {
+    echo 1>&2 "WARNING: no tests run."
+}
+
+build_release() {
+    cd "$BASE"
+    mkdir -p release
+    cp README.md release/
+    tar czf release/eccube-omise.tar.gz \
+        class config.php inc logo.png mdl_omise \
+        OmiseExt.php omise-php plugin_info.php templates
+}
+
+commit_release() {
+    # Use https://github.com/cynic-net/git-commit-filetree here
+    echo 1>&2 "ERROR: commit_release not written!"
+    exit 1
+}
+
+run_tests
+build_release
+if [ _--commit = _"$1" ]; then
+    commit_release
+else
+    echo "Release tarball is in release/ subdir."
+    echo "Use --commit option to commit release to release branch."
+fi


### PR DESCRIPTION
#### 1. Objective reason

Usually we let people click `download` button from GitHub page (git archive command).
But, EC-Cube required that all files of plugin must keep to the root-top-level directory instead of put all files to a folder. 

i.e.

```
omise-eccube.tar.gz
./class
./class/*
./OmiseExt.php
./plugin_info.php
```

which EC-Cube can't handle what the git archive did (git archive try to put everything inside `omise-eccube` folder). So, we changed our minds and gonna put `tar.gz` file to the repo and let people download from that file instead.

So, @cjs-cynic-net made a build script to help us easily build that `tar.gz` file
#### 2. Description of change
1. Implemented build script
#### 3. Developers affected by the change

`-`
#### 4. Impact of the change

`-`
#### 5. Priority of change

:star2: :star: :star:
#### 6. Alternate solution (if any)**

`-`
