### PR TITLE
Validate a charge result before update an order status.

### DIFF
--- a/class/models/Omise_Models_Charge.php
+++ b/class/models/Omise_Models_Charge.php
@@ -226,13 +226,18 @@ class Omise_Models_Charge
         }
 
         try {
-            $objCharge = OmiseWrapper::chargeCapture($this->getChargeId());
+            $charge = OmiseWrapper::chargeCapture($this->getChargeId());
+
+            $result = $this->validateChargeCaptured($charge);
+            if ($result !== true) {
+                throw new Exception($result);
+            }
         } catch (OmiseException $e) {
             return $e->getMessage();
         }
 
         $objPurchase = new SC_Helper_Purchase_Ex();
-        $updateData  = array(OMISE_MDL_CHARGE_DATA_COL => $this->lfConvertToDbChargeData($objCharge));
+        $updateData  = array(OMISE_MDL_CHARGE_DATA_COL => $this->lfConvertToDbChargeData($charge));
         $objQuery    = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
         $objPurchase->sfUpdateOrderStatus(

--- a/class/models/Omise_Models_Charge.php
+++ b/class/models/Omise_Models_Charge.php
@@ -282,6 +282,7 @@ class Omise_Models_Charge
     /**
      * Validate if charge is authorized.
      *
+     * @param  OmiseCharge  $charge
      * @return string|bool  The error message if occured
      */
     protected function validateChargeAuthorized($charge)
@@ -300,6 +301,7 @@ class Omise_Models_Charge
     /**
      * Validate if charge is captured.
      *
+     * @param  OmiseCharge  $charge
      * @return string|bool  The error message if occured
      */
     protected function validateChargeCaptured($charge)

--- a/class/models/Omise_Models_Charge.php
+++ b/class/models/Omise_Models_Charge.php
@@ -145,13 +145,23 @@ class Omise_Models_Charge
     {
         $arrChargeParams = $this->lfComposeChargeParam($arrPayer);
         try {
-            $objCharge = OmiseWrapper::chargeCreate($arrChargeParams);
-        } catch (OmiseException $e) {
+            $charge = OmiseWrapper::chargeCreate($arrChargeParams);
+
+            if ($charge['capture']) {
+                $result = $this->validateChargeCaptured($charge);
+            } else {
+                $result = $this->validateChargeAuthorized($charge);
+            }
+
+            if ($result !== true) {
+                throw new Exception($result);
+            }
+        } catch (Exception $e) {
             return $e->getMessage();
         }
 
         $objPurchase = new SC_Helper_Purchase_Ex();
-        $updateData  = array(OMISE_MDL_CHARGE_DATA_COL => $this->lfConvertToDbChargeData($objCharge));
+        $updateData  = array(OMISE_MDL_CHARGE_DATA_COL => $this->lfConvertToDbChargeData($charge));
         $objQuery    = SC_Query_Ex::getSingletonInstance();
         $objQuery->begin();
         $objPurchase->sfUpdateOrderStatus(
@@ -267,5 +277,41 @@ class Omise_Models_Charge
         $objPurchase->sendOrderMail($this->arrOrder['order_id']);
 
         return null;
+    }
+
+    /**
+     * Validate if charge is authorized.
+     *
+     * @return string|bool  The error message if occured
+     */
+    protected function validateChargeAuthorized($charge)
+    {
+        if (! isset($charge['object']) || $charge['object'] !== 'charge') {
+            return '注文情報の状態が不正です。<br>この手続きは無効となりました。';
+        }
+
+        if ($charge['status'] === 'pending' && $charge['authorized'] === true) {
+            return true;
+        }
+
+        return "支払いに失敗しました、" . $charge['failure_message'] . ' (' . $charge['failure_code'] . ')';
+    }
+
+    /**
+     * Validate if charge is captured.
+     *
+     * @return string|bool  The error message if occured
+     */
+    protected function validateChargeCaptured($charge)
+    {
+        if (! isset($charge['object']) || $charge['object'] !== 'charge') {
+            return '注文情報の状態が不正です。<br>この手続きは無効となりました。';
+        }
+
+        if ($charge['status'] === 'successful' && $charge['paid'] === true) {
+            return true;
+        }
+
+        return "支払いに失敗しました、" . $charge['failure_message'] . ' (' . $charge['failure_code'] . ')';
     }
 }


### PR DESCRIPTION
#### 1. Objective

Validate a charge result before update an order status and redirect buyer to the order completed page.

**Related information**:
Related issue(s): T2474
Related ticket(s): 🙅

#### 2. Description of change

- Add condition to validate a charge result after create a charge transaction.
- Also check a charge result for manual capture.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: EC-Cube v2.13.3.
- **Omise plugin version**: Omise-Eccube v2.13.0.0.
- **PHP version**: 5.6.28.

**✏️ Details:**

> Note, test case number 1, 2 and 3 were tested to make sure that the current checkout method functions as well (both authorize only & authorize and capture).

1. ✅ At plugin setting page, set `キャプチャ` option to `購入時に即時、実売上化する` (auto capture) and do checkout with normal card.

    **expectation**

    - Checkout success and redirect buyer to the `order complete` page.

    - Order will be created with a status `入金済み` (payment completed).  

    _Setting screen_
    ![screen shot 2560-02-28 at 4 02 00 am](https://cloud.githubusercontent.com/assets/2154669/23379754/b4dfa0f2-fd6a-11e6-9720-feed5129e659.png)

    _EC-Cube's order detail page_
    ![screen shot 2560-02-28 at 5 21 47 am](https://cloud.githubusercontent.com/assets/2154669/23382718/ea556eaa-fd75-11e6-8c5c-3707f116d825.png)

    _Charge detail at Omise dashboard_
    ![screen shot 2560-02-28 at 5 26 49 am](https://cloud.githubusercontent.com/assets/2154669/23382907/a2a2d1fa-fd76-11e6-8eb8-bbdc5ba06c05.png)

2. ✅ At plugin setting page, set `キャプチャ` option to `購入時に仮売上（オーソリ）を作成し、受注管理画面から実売上化する` (authorize only) and do checkout with normal card.

    **expectation**

    - Checkout success and redirect buyer to the `order complete` page.

    - Order will be created with a status `入金待ち` (waiting for payment).

    _Setting screen_
    ![screen shot 2560-02-28 at 4 02 02 am](https://cloud.githubusercontent.com/assets/2154669/23379755/b54147c6-fd6a-11e6-8477-91a69c006297.png)

    _EC-Cube's order detail page_
    ![screen shot 2560-02-28 at 5 22 01 am](https://cloud.githubusercontent.com/assets/2154669/23382717/ea53762c-fd75-11e6-8e60-f296aa6ac3b9.png)

    _Charge detail at Omise dashboard_
    ![screen shot 2560-02-28 at 5 27 23 am](https://cloud.githubusercontent.com/assets/2154669/23382908/a31b892e-fd76-11e6-894c-8deaa4fbbcd8.png)

    Tested by using test card.
    <img width="1157" alt="screen shot 2560-02-28 at 5 05 05 am" src="https://cloud.githubusercontent.com/assets/2154669/23382716/e9d0673c-fd75-11e6-9e67-93d92031416c.png">

    Both tests will redirect buyer to the `order complete` page.
    <img width="1194" alt="screen shot 2560-02-28 at 4 16 51 am" src="https://cloud.githubusercontent.com/assets/2154669/23381518/5815b9a4-fd71-11e6-8bc2-edf38fea39d2.png">


3. ✅ Test do manual capture with an authorized charge from the EC-Cube order detail page.

    **expectation**

    - Charge will be captured

    _Do manual capture at the order detail page_
    ![screen shot 2560-02-28 at 6 00 50 am](https://cloud.githubusercontent.com/assets/2154669/23383987/7c3982ac-fd7b-11e6-84ee-99372d6a7efb.png)

    _Charge was captured, checked at Omise dashboard_
    ![screen shot 2560-02-28 at 6 01 42 am](https://cloud.githubusercontent.com/assets/2154669/23383988/7ca70598-fd7b-11e6-9f1c-e69c9ba0c107.png)

...

> Note, test case number 4 and 5 were tested to make sure that a failed test card will raise an error properly and not redirect buyer to the `order complete` page.

4. ✅ At plugin setting page, set `キャプチャ` option to `購入時に即時、実売上化する` (auto capture) and do checkout with any of [failed charge cards](https://www.omise.co/api-testing).

5. ✅ At plugin setting page, set `キャプチャ` option to `購入時に仮売上（オーソリ）を作成し、受注管理画面から実売上化する` (authorize only) and do checkout with any of [failed charge cards](https://www.omise.co/api-testing).

    **expectation (for both 4th and 5th tests)**

    - Checkout will consider to be failed and raise an error to the checkout screen.

    - Order will be created with a status `決済処理中` (pending, it's a default status for a new order, which means, if payment fail we will not update any status of an order).

    _An error was raised at the checkout page if payment is failed_
    <img width="1157" alt="screen shot 2560-02-28 at 5 42 08 am" src="https://cloud.githubusercontent.com/assets/2154669/23383490/38738d76-fd79-11e6-9d2f-d4403f685d15.png">

    _Status will be `決済処理中`_
    ![screen shot 2560-02-28 at 5 54 38 am](https://cloud.githubusercontent.com/assets/2154669/23383748/865ca10c-fd7a-11e6-8e13-008a474fff24.png)

    _Charge detail at Omise dashboard_
    ![screen shot 2560-02-28 at 5 43 11 am](https://cloud.githubusercontent.com/assets/2154669/23383491/38f12dc6-fd79-11e6-9f9d-0a977980d33d.png)
    

#### 4. Impact of the change

Nothing.

#### 5. Priority of change

High.

#### 6. Additional Notes

Nothing.